### PR TITLE
Fix for SyntaxError in bootstrap()

### DIFF
--- a/erds/erds.py
+++ b/erds/erds.py
@@ -28,8 +28,8 @@ def bootstrap(x, n_resamples=300, statistic="mean", alpha=0.01, axis=0):
         statistic = np.mean
     elif statistic == "median":
         statistic = np.median
-    mask = [m for i, m in enumerate(x.shape) if i != axis]
-    resamples = np.empty((n_resamples, *mask))
+    mask = [n_resamples] + [m for i, m in enumerate(x.shape) if i != axis]
+    resamples = np.empty(mask)
     for sample in range(n_resamples):
         idx = np.random.randint(0, x.shape[axis], size=x.shape[axis])
         resamples[sample] = statistic(np.take(x, idx, axis), axis)


### PR DESCRIPTION
On Python 3.4.3 I get:

```
  File "C:/workspace/git/erds/erds/erds.py", line 32
    resamples = np.empty((n_resamples, *mask))
                                      ^
SyntaxError: can use starred expression only as assignment target
```

This PR avoids construction of the size tuple with a starred expression.